### PR TITLE
라이브러리 체크 로직 변경

### DIFF
--- a/src/vue-daum-postcode.js
+++ b/src/vue-daum-postcode.js
@@ -5,7 +5,7 @@ const loadedRejects = []
 
 function loadScript() {
   return new Promise((resolve, reject) => {
-    if (window.daum && window.daum) {
+    if (window.daum && window.daum.postcode) {
       return resolve()
     }
     loadedResolves.push(resolve)


### PR DESCRIPTION
우편번호 라이브러리가 임포트 되어 있는지 검사하는 로직이 중복되어 있습니다

그러므로 중복체크 로직을

다른 다음 라이브러리(예 : 다음 지도)를 사용 할 수도 있기에 window.daum.postcode 로 변경